### PR TITLE
add CJS support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+exports.Note = require('./src/Note');
+exports.Sequence = require('./src/Sequence');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "TinyMusic",
   "version": "0.0.1",
   "description": "A simple, lightweight music sequencer in JavaScript using the Web Audio API.",
-  "main": "Gruntfile.js",
+  "main": "./index.js",
   "scripts": {
     "test": "grunt"
   },

--- a/src/Note.js
+++ b/src/Note.js
@@ -57,3 +57,5 @@ Note.getDuration = function( symbol ) {
         curr === 's' ? 0.25 : 0 );
     }, 0 );
 };
+
+typeof module !== 'undefined' && (module.exports = Note);

--- a/src/Sequence.js
+++ b/src/Sequence.js
@@ -120,3 +120,5 @@ Sequence.prototype.stop = function() {
   }
   return this;
 };
+
+typeof module !== 'undefined' && (module.exports = Sequence);


### PR DESCRIPTION
Hello!

This is a super cool library! I wanted to be able to `require` it from places like requirebin as well as using browserify. I tried to make this change as unobtrusive as possible, so the API hasn't changed at all, and the code changes were negligible size-wise. I also made the bare-minimum UMD guard for each file... while not perfectly safe I think it's safe enough.

Are you open to allowing this?

There is a slightly more safe variant that would involve the `./dist` versions actually being a standalone browserified version, but I figured that was too big of a change to just spring on someone (also worried about how much compiled code that would add).
