### PR TITLE
OscillatorNode no longer allows you to set the type to 'custom'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test/shims.js
 .DS_Store
 *.sizecache.json
 *.log
+.idea/

--- a/src/Sequence.js
+++ b/src/Sequence.js
@@ -54,7 +54,6 @@ Sequence.prototype.createCustomWave = function( real, imag ) {
 Sequence.prototype.createOscillator = function() {
   this.stop();
   this.osc = this.ac.createOscillator();
-  this.osc.type = this.waveType || 'square';
 
   // customWave should be an array of Float32Arrays. The more elements in
   // each Float32Array, the dirtier (saw-like) the wave is
@@ -62,6 +61,8 @@ Sequence.prototype.createOscillator = function() {
     this.osc.setPeriodicWave(
       this.ac.createPeriodicWave.apply( this.ac, this.customWave )
     );
+  } else {
+    this.osc.type = 'square';
   }
 
   this.osc.connect( this.gain );

--- a/src/Sequence.js
+++ b/src/Sequence.js
@@ -62,7 +62,7 @@ Sequence.prototype.createOscillator = function() {
       this.ac.createPeriodicWave.apply( this.ac, this.customWave )
     );
   } else {
-    this.osc.type = 'square';
+    this.osc.type = this.waveType || 'square';
   }
 
   this.osc.connect( this.gain );


### PR DESCRIPTION
When attempting to create a custom wave on a sequence, Firefox 39 was reporting the following error:

> Uncaught InvalidStateError: Failed to set the 'type' property on 'OscillatorNode': 'type' cannot be set directly to 'custom'.  Use setPeriodicWave() to create a custom Oscillator type.

OscillatorNode no longer seems to allow you to set the type to 'custom', it is sufficient to set the periodic wave only. Tested this change in Chrome and Firefox 39 on a Macbook Pro.

Grunt reported no issues when run, all tests passed.