### PR TITLE
Change note scheduling style

### DIFF
--- a/src/Sequence.js
+++ b/src/Sequence.js
@@ -85,6 +85,29 @@ Sequence.prototype.scheduleNote = function( index, when ) {
   return when + duration;
 };
 
+//setup when notes will run at current tempo
+Sequence.prototype.planTimingsForRemainingNotes = function ( startIndex, when ) {
+  var tempo = this.tempo;
+  this.notes.slice(startIndex).forEach(function(note, index){
+	note.scheduled = false;
+	note.scheduledTime = when;
+	when = when + 60 / tempo * note.duration;
+  });
+  return when;
+};
+
+Sequence.prototype.setTempo = function( tempo ) {
+	if (tempo === this.tempo) return;
+	var preScheduled = this.notes.filter(function(n) { return n.scheduled; }).length;
+	var oldTempo = this.tempo;
+	this.tempo = tempo;
+	if (preScheduled > 0) {
+		this.planTimingsForRemainingNotes( preScheduled, this.notes[ preScheduled - 1 ].duration * (60 / oldTempo));
+	} else {
+		this.planTimingsForRemainingNotes( 0, this.startTime );
+	}
+}
+
 // get the next note
 Sequence.prototype.getNextNote = function( index ) {
   return this.notes[ index < this.notes.length - 1 ? index + 1 : 0 ];
@@ -120,22 +143,39 @@ Sequence.prototype.rampFrequency = function( freq, when ) {
 // run through all notes in the sequence and schedule them
 Sequence.prototype.play = function( when ) {
   when = typeof when === 'number' ? when : this.ac.currentTime;
-
+  this.startTime = when;
   this.createOscillator();
+  var schedule = (function() {
+      this.notes.forEach((function(note, index){
+          if (note.scheduled) {
+              return;
+          }
+          if (note.scheduledTime <= (this.ac.currentTime + 0.1)) { //schedule 100 ms out
+              var done = this.scheduleNote(index, note.scheduledTime);
+              note.scheduled = true;
+              if (index === this.notes.length-1) { //Last note scheduled. If on loop, reschedule all notes
+                  if (this.loop) {
+                      this.startTime = done;
+                      this.planTimingsForRemainingNotes(0, done);
+                  } else {
+                      this.osc.stop(done);
+                  }
+              }
+          }
+      }).bind(this));
+  }).bind(this);
+  this.scheduler = setInterval(schedule, 60); //run the scheduler every 60ms
+  
+  this.planTimingsForRemainingNotes(0, when);
+  
+  schedule();
   this.osc.start( when );
-
-  this.notes.forEach(function( note, i ) {
-    when = this.scheduleNote( i, when );
-  }.bind( this ));
-
-  this.osc.stop( when );
-  this.osc.onended = this.loop ? this.play.bind( this, when ) : null;
-
   return this;
 };
 
 // stop playback, null out the oscillator, cancel parameter automation
 Sequence.prototype.stop = function() {
+  clearInterval(this.scheduler);
   if ( this.osc ) {
     this.osc.onended = null;
     this.osc.disconnect();


### PR DESCRIPTION
To allow tempo to be altered at runtime between notes. Specifically, this uses a sliding window - every 60ms the scheduler schedules all unscheduled notes for the next 100ms at the current tempo - those parameters are tweakable, but IMO they give a good balance of scheduling ahead and accounting for latency in setInterval callbacks. 

One thing I have yet to decide the goodness of is line 105 - when I choose to kick in tempo changes. It waits for the last scheduled note to finish (as per its old tempo), and schedules notes at the new tempo after that. This makes sense until you start playing sequences in parallel - this method can cause parallel sequences to desync from one another as they can adopt the new tempo at different times (since their active/last scheduled notes can be of different lengths). This can be avoided if you know it's there by delaying your setTempo call until you know notes of the same duration have been scheduled between all of your parallel sequences... but it's awkward. I'm wondering if there's a decision to be made here which can make that easier.